### PR TITLE
Add resHeaders support

### DIFF
--- a/src/createBunHttpHandler.ts
+++ b/src/createBunHttpHandler.ts
@@ -2,8 +2,9 @@ import { Server } from "bun";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { AnyRouter, inferRouterContext } from "@trpc/server";
 import type { HTTPBaseHandlerOptions } from "@trpc/server/http";
+import type { FetchCreateContextFnOptions } from '@trpc/server/adapters/fetch'
 
-export type CreateBunContextOptions = { req: Request };
+export type CreateBunContextOptions = FetchCreateContextFnOptions 
 
 export type BunHttpHandlerOptions<TRouter extends AnyRouter> =
     HTTPBaseHandlerOptions<TRouter, Request> & {


### PR DESCRIPTION
This would be sufficient to support both `resHeaders` and `info` fields. Also, I recommend to push `bun.lockb` to github to avoid incompatible versions between contributors, what you think @cah4a ?

closes https://github.com/cah4a/trpc-bun-adapter/issues/5