### PR TITLE
add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .vscode
 .idea
 .DS_Store
+.envrc
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "bun-nixpkgs": {
+      "locked": {
+        "lastModified": 1729062649,
+        "narHash": "sha256-CK6qxfqA4xkAteMaMrJzC4sfko3l61gvqnRyMoB88R4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f27f172be3bfa955a8d5a280ba60f12f90164ccb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f27f172be3bfa955a8d5a280ba60f12f90164ccb",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729265718,
+        "narHash": "sha256-4HQI+6LsO3kpWTYuVGIzhJs1cetFcwT7quWCk/6rqeo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ccc0c2126893dd20963580b6478d1a10a4512185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bun-nixpkgs": "bun-nixpkgs",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    bun-nixpkgs.url = "github:nixos/nixpkgs/f27f172be3bfa955a8d5a280ba60f12f90164ccb";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    bun-nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+
+        config = {
+          allowUnfree = true;
+        };
+      };
+
+      bun-pkgs = import bun-nixpkgs {inherit system;};
+
+      node = pkgs.nodejs-slim_22;
+      bun = bun-pkgs.bun;
+    in {
+      devShell = pkgs.mkShell {
+        buildInputs = [
+          node
+          bun
+        ];
+
+        env = {
+          NODE_ENV = "development";
+        };
+      };
+    });
+}


### PR DESCRIPTION
adds a nix flake and direnv .envrc file to trigger it automatically via nix-direnv for establishing a consistent development environment.
node 22 and bun 1.1.30 added.

needed this to release this more consistently for internal usage because the current repository is not tagging releases that are made to npm, and the npm release does not include the latest `connectionParams` feature present on master.

Thanks for the work cah4a, this was fun to drop in to an existing Bun.serve codebase that was using trpc's fetch handler directly. Because you've split up the ws handler creation, it saved us a lot of time without needing to refactor anything existing. I'll drop the fork when we can use the latest feature, but the nix flake is always useful to have in any project regardless :)