### PR TITLE
Update README.md to make it more clear that storing the request object on the Bun websocket data context is required for the websocket transport to work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,10 @@ const websocket = createBunWSHandler({
 
 Bun.serve({
     fetch(request, server) {
-        if (server.upgrade(request, {data: {req: request}})) {
+        const data = {
+            req: request // This is required for the adapter to work properly.
+        };
+        if (server.upgrade(request, { data })) {
             return;
         }
 
@@ -182,6 +185,8 @@ Bun.serve({
     websocket,
 });
 ```
+
+> Note that it is required to store the request object on the socket data context in order for this adapter to work.
 
 ### CreateBunContextOptions
 


### PR DESCRIPTION
I couldn't figure out why my implementation of the websocket handler wasn't working until I debugged into the library itself and noticed it trying to read `req` off of `ws.data`. At that point I assumed Bun must have included the request on the context object automatically in some previous version so I modified my code to manually add the request to the socket context and the problem went away.

Then I decided to look at the documentation to make sure I didn't miss something. Turns out I did miss that this was being done in the code snippet. The first time I went over the README I think I assumed that bit of code was just a demonstration of storing something on the socket data context and did not realize it was a requirement for the library to work in the first place.

I figured this callout might help others avoid this misadventure.